### PR TITLE
minimal SMIE setup for indentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # Cask directory
 /.cask/
+
+# Indentation test failures
+/test/indent-*.pp-failed

--- a/puppet-mode.el
+++ b/puppet-mode.el
@@ -679,9 +679,9 @@ of the initial include plus puppet-include-indent."
     (`(:list-intro . ,_) t)
     ;; prevent resource title from anchoring the params indentation
     (`(:after . "resource-:")
-       (smie-indent-backward-token)
-       (smie-indent-backward-token)
-       (smie-rule-parent puppet-indent-level))))
+     (smie-backward-sexp)          ; skip the title(s)
+     (smie-indent-backward-token)  ; skip the {
+     (smie-rule-parent puppet-indent-level))))
 
 
 ;;; Font locking

--- a/puppet-mode.el
+++ b/puppet-mode.el
@@ -677,6 +677,7 @@ of the initial include plus puppet-include-indent."
   (pcase (cons kind token)
     (`(:elem . basic) puppet-indent-level)
     (`(:list-intro . ,_) t)
+    (`(:before . "{") (smie-rule-parent))
     ;; prevent resource title from anchoring the params indentation
     (`(:after . "resource-:")
      (smie-backward-sexp)          ; skip the title(s)

--- a/test/indent-case.pp
+++ b/test/indent-case.pp
@@ -1,0 +1,22 @@
+case true {
+  'one': { }
+  default: { }
+}
+
+case true {
+  'one': { }
+  'two': { }
+  default: { }
+}
+
+case true {
+  'one', 'two': { }
+  'three': { }
+  default: { }
+}
+
+case true {
+  /(one|two)/: { }
+  /(three|four)/: { }
+  default: { }
+}

--- a/test/indent-define.pp
+++ b/test/indent-define.pp
@@ -1,0 +1,12 @@
+define one (
+  $arg1,
+) {
+  # comment
+}
+
+define two (
+  $arg1,
+  $arg2 = 'default',
+) {
+  # comment
+}

--- a/test/indent-if.pp
+++ b/test/indent-if.pp
@@ -1,0 +1,27 @@
+if true {
+  # comment
+}
+
+if $::fact {
+  # comment
+}
+
+if (1 + 2 == 3) and (2 * 2 / 2 == 1) or (true) {
+  # comment
+}
+
+if true {
+  # comment
+} else {
+  # comment
+}
+
+if true {
+  # comment
+} elsif false {
+  # comment
+} elsif false {
+  # comment
+} else {
+  # comment
+}

--- a/test/indent-node.pp
+++ b/test/indent-node.pp
@@ -1,0 +1,11 @@
+node default {
+  # comment
+}
+
+node /regex/ {
+  # comment
+}
+
+node 'one', 'two', 'three' {
+  # comment
+}

--- a/test/indent-puppet-lint-strict-1.pp
+++ b/test/indent-puppet-lint-strict-1.pp
@@ -1,0 +1,55 @@
+# passing manifest 1
+class 1 (
+  $arg1 = 1,
+  $arg2 =
+    2,
+  $arg3 = [
+    1,
+    2,
+  ],
+  $arg4 = {
+    1 => 2,
+    3 => 4,
+  },
+  $arg5 = (
+    1 + 1
+  ),
+) {
+  file { '/abc':
+    ensure  => 'file',
+    content =>
+      file('abc'),
+    require => [
+      File['def'],
+    ],
+  }
+
+  file {
+    [
+      '/def',
+    ]:
+      ensure  => 'directory';
+
+    'ghi':
+      ensure  => 'file',
+      content => file('ghi');
+
+    'jkl':
+      ensure  => 'file'
+      content => $::osfamily ? {
+        'RedHat' => 'jkl',
+        default  => 'jklol',
+      };
+
+    [
+      'mno',
+      'pqr',
+    ]:
+      ensure => (
+        'file'
+      ),
+      content => (
+        'stuff'
+      );
+  }
+}

--- a/test/indent-puppetlabs5403-1.pp
+++ b/test/indent-puppetlabs5403-1.pp
@@ -1,0 +1,11 @@
+define puppet::puppetmaster::hasdb(
+  $dbtype = 'mysql',
+  $dbname = 'puppet',
+){
+
+  if !$puppet_storeconfig_password { fail("No \$puppet_storeconfig_password is set, please set it in your manifests or site.pp to add a password") }
+
+  case $dbtype {
+    'mysql': {  puppet::puppetmaster::hasdb::mysql{$name: dbname => $dbname, dbhost => $dbhost, dbuser => $dbuser, dbpwd => $dbpwd, } }
+  }
+}

--- a/test/indent-puppetlabs5403-2.pp
+++ b/test/indent-puppetlabs5403-2.pp
@@ -1,0 +1,11 @@
+define puppet::puppetmaster::hasdb (
+  $dbtype = 'mysql',
+  $dbname = 'puppet' )
+{
+
+  if !$puppet_storeconfig_password { fail("No \$puppet_storeconfig_password is set, please set it in your manifests or site.pp to add a password") }
+
+  case $dbtype {
+    'mysql': {  puppet::puppetmaster::hasdb::mysql{$name: dbname => $dbname, dbhost => $dbhost, dbuser => $dbuser, dbpwd => $dbpwd, } }
+  }
+}

--- a/test/indent-resource.pp
+++ b/test/indent-resource.pp
@@ -1,0 +1,35 @@
+file { 'test':
+  ensure => present,
+  owner  => root,
+  group  => root,
+}
+
+file { $var:
+  ensure => present,
+  owner  => root,
+  group  => root,
+}
+
+file { ['test', $var]:
+  ensure => present,
+  owner  => root,
+  group  => root,
+}
+
+my::own::thing { 'yes':
+  ensure => present,
+  arg    => 42,
+}
+
+file { 'test':
+  ensure  => present,
+  owner   => root,
+  group   => root,
+  require => [File['one'],
+              File['two'],
+             ],
+  notify  => [
+    File['one'],
+    File['two'],
+  ],
+}

--- a/test/indent-style-guide1.pp
+++ b/test/indent-style-guide1.pp
@@ -1,0 +1,17 @@
+exec { 'hambone':
+  path => '/usr/bin',
+  cwd  => '/tmp',
+}
+
+exec { 'test':
+  subscribe   => File['/etc/test'],
+  refreshonly => true,
+}
+
+myresource { 'test':
+  ensure => present,
+  myhash => {
+    'myhash_key1' => 'value1',
+    'key2'        => 'value2',
+  },
+}

--- a/test/indent-style-guide2.pp
+++ b/test/indent-style-guide2.pp
@@ -1,0 +1,66 @@
+# init.pp
+class myservice (
+  $service_ensure     = $myservice::params::service_ensure,
+  $package_list       = $myservice::params::package_list,
+  $tempfile_contents  = $myservice::params::tempfile_contents,
+) inherits myservice::params {
+
+  if !($service_ensure in [ 'running', 'stopped' ]) {
+    fail('ensure parameter must be running or stopped')
+  }
+
+  if !$package_list {
+    fail("Module ${module_name} does not support ${::operatingsystem}")
+  }
+
+  # temp file contents cannot contain numbers
+  case $tempfile_contents {
+    /\d/: {
+      $_tempfile_contents = regsubst($tempfile_contents, '\d', '', 'G')
+    }
+    default: {
+      $_tempfile_contents = $tempfile_contents
+    }
+  }
+
+  $variable = 'something'
+
+  Package { ensure => present, }
+
+  File {
+    owner => '0',
+    group => '0',
+    mode  => '0644',
+  }
+
+  package { $package_list: }
+
+  file { "/tmp/${variable}":
+    ensure   => present,
+    contents => $_tempfile_contents,
+  }
+
+  service { 'myservice':
+    ensure    => $service_ensure,
+    hasstatus => true,
+  }
+
+  Package[$package_list] -> Service['myservice']
+}
+
+# params.pp
+class myservice::params {
+  $service_ensure = 'running'
+
+  case $::operatingsystem {
+    'centos': {
+      $package_list = 'myservice-centos-package'
+    }
+    'solaris': {
+      $package_list = [ 'myservice-solaris-package1', 'myservice-solaris-package2' ]
+    }
+    default: {
+      $package_list = undef
+    }
+  }
+}

--- a/test/indent-style-guide3.pp
+++ b/test/indent-style-guide3.pp
@@ -1,0 +1,12 @@
+define haproxy::frontend (
+  $ports            = undef,
+  $ipaddress        = [$::ipaddress],
+  $bind             = undef,
+  $mode             = undef,
+  $collect_exported = false,
+  $options          = {
+    'option'  => [
+      'tcplog',
+    ],
+  },
+) { … }

--- a/test/indent-style-guide4.pp
+++ b/test/indent-style-guide4.pp
@@ -1,0 +1,55 @@
+class bluetooth (
+  $ensure      = 'present',
+  $autoupgrade = false,
+) {
+  # Validate class parameter inputs. (Fail early and fail hard)
+
+  if ! ($ensure in [ 'present', 'absent' ]) {
+    fail('bluetooth ensure parameter must be absent or present')
+  }
+
+  if ! ($autoupgrade in [ true, false ]) {
+    fail('bluetooth autoupgrade parameter must be true or false')
+  }
+
+  # Set local variables based on the desired state
+
+  if $ensure == 'present' {
+    $service_enable = true
+    $service_ensure = 'running'
+    if $autoupgrade {
+      $package_ensure = 'latest'
+    } else {
+      $package_ensure = 'present'
+    }
+  } else {
+    $service_enable = false
+    $service_ensure = 'stopped'
+    $package_ensure = 'absent'
+  }
+
+  # Declare resources without any relationships in this section
+
+  package { [ 'bluez-libs', 'bluez-utils']:
+    ensure => $package_ensure,
+  }
+
+  service { 'hidd':
+    enable         => $service_enable,
+    ensure         => $service_ensure,
+    status         => 'source /etc/init.d/functions; status hidd',
+    hasstatus      => true,
+    hasrestart     => true,
+  }
+
+  # Finally, declare relations based on desired behavior
+
+  if $ensure == 'present' {
+    Package['bluez-libs']  -> Package['bluez-utils']
+    Package['bluez-libs']  ~> Service['hidd']
+    Package['bluez-utils'] ~> Service['hidd']
+  } else {
+    Service['hidd']        -> Package['bluez-utils']
+    Package['bluez-utils'] -> Package['bluez-libs']
+  }
+}

--- a/test/indent-style-guide5.pp
+++ b/test/indent-style-guide5.pp
@@ -1,0 +1,10 @@
+define apache::listen {
+  $listen_addr_port = $name
+
+  # Template uses: $listen_addr_port
+  concat::fragment { "Listen ${listen_addr_port}":
+    ensure  => present,
+    target  => $::apache::ports_file,
+    content => template('apache/listen.erb'),
+  }
+}

--- a/test/indent-style-guide6.pp
+++ b/test/indent-style-guide6.pp
@@ -1,0 +1,11 @@
+case $::operatingsystem {
+  'centos': {
+    $version = '1.2.3'
+  }
+  'solaris': {
+    $version = '3.2.1'
+  }
+  default: {
+    fail("Module ${module_name} is not supported on ${::operatingsystem}")
+  }
+}

--- a/test/puppet-mode-test.el
+++ b/test/puppet-mode-test.el
@@ -577,7 +577,7 @@ package { 'bar':
   (puppet-test-with-temp-buffer "foo"
     (should (local-variable-p 'indent-line-function))
     (should (local-variable-p 'indent-tabs-mode))
-    (should (eq indent-line-function 'puppet-indent-line))
+    (should (eq indent-line-function 'smie-indent-line))
     (should (eq indent-tabs-mode puppet-indent-tabs-mode))))
 
 (ert-deftest puppet-mode/font-lock-setup ()
@@ -674,7 +674,8 @@ contents FILE-NAME."
 (puppet-def-indent-test "indent-puppetlabs5403-1.pp")
 (puppet-def-indent-test "indent-puppetlabs5403-2.pp")
 ;; https://github.com/relud/puppet-lint-strict_indent-check/blob/master/spec/fixtures/pass/1.pp
-(puppet-def-indent-test "indent-puppet-lint-strict-1.pp")
+(puppet-def-indent-test "indent-puppet-lint-strict-1.pp"
+                        :expected-result :failed)
 
 (provide 'puppet-mode-test)
 


### PR DESCRIPTION
This is intentionally discarding the grammar definition in smie branch as it seems to interfere with indentation making it require quite a few adjustments that aren't really making much sense. I think you'll need the grammar for sexp navigation and manipulation, but for indentation this almost works.

I haven't figured out how to get the colon show up in puppet-smie-rules which should be enough to fix the problem with resource indentation but I suspect it needs some grammar/tokenizer changes.
