### PR TITLE
Added failing test for alignment of nested blocks

### DIFF
--- a/test/puppet-mode-test.el
+++ b/test/puppet-mode-test.el
@@ -519,6 +519,33 @@ package { 'bar':
   install_options => [],
 }"))))
 
+(ert-deftest puppet-align-block/nested-blocks ()
+  :tags '(alignment)
+  :expected-result :failed
+  (puppet-test-with-temp-buffer
+      "
+package { 'foo':
+  ensure => latest,
+  require    => Package['bar'],
+  install_options =>   ['--foo', '--bar'],
+  foo => {
+    bar => 'qux',
+    quxc => 'bar',
+  }
+}"
+    (search-forward "'foo':")
+    (puppet-align-block)
+    (should (string= (buffer-string) "
+package { 'foo':
+  ensure          => latest,
+  require         => Package['bar'],
+  install_options => ['--foo', '--bar'],
+  foo             => {
+    bar  => 'qux',
+    quxc => 'bar',
+  }
+}"))))
+
 
 ;;;; Imenu
 


### PR DESCRIPTION
The test is currently failing, as the result of `puppet-align-block` on line 2-5 of the test is

`````` puppet
package { 'foo':
  ensure          => latest,
  require         => Package['bar'],
  install_options => ['--foo', '--bar'],
  foo             => {
    cbar          => 'qux',
    quxc          => 'bar',
  }
}```

As per the [Puppet style guide](https://docs.puppet.com/guides/style_guide.html#arrow-alignment), the arrows of each block should be aligned independently, e.g.:

```puppet
myresource { 'test':
  ensure => present,
  myhash => {
    'myhash_key1' => 'value1',
    'key2'        => 'value2',
  },
}
``````

This pull requests adds a test for that case.
