### PR TITLE
Fix binding repl-args when calling make-comint

### DIFF
--- a/puppet-mode.el
+++ b/puppet-mode.el
@@ -279,6 +279,7 @@ Return nil, if there is no special context at POS, or one of
     (set-buffer
      (apply 'make-comint "Puppet-REPL"
             puppet-repl-command
+            nil
             puppet-repl-args))
     ;; Workaround for ansi colors
     (add-hook 'comint-preoutput-filter-functions 'puppet-comint-filter nil t))


### PR DESCRIPTION
The argument after make-comint's PROGRAM argument is STARTFILE.
Not setting it to nil results in the first value of puppet-repl-args
being bound to it. This is not right, since all of puppet-repl-args
are expected to be flags for the repl command and not STARTFILE.