### PR TITLE
Fix indent handling of class params closing paren

### DIFF
--- a/puppet-mode.el
+++ b/puppet-mode.el
@@ -658,7 +658,7 @@ of the initial include plus puppet-include-indent."
 
        ;; Class argument list ends with a closing paren and needs to be
        ;; indented to the level of the class token.
-       ((looking-at "^\s+\).*?{\s*$")
+       ((looking-at "^\s*\).*?{\s*$")
         ;; Find the indentation level of the opening line.
         (let ((prev-class-indentation nil))
           (save-excursion

--- a/test/puppet-mode-test.el
+++ b/test/puppet-mode-test.el
@@ -690,6 +690,38 @@ $bar = 'hello'
 }"
 ))))
 
+(ert-deftest puppet-indent-line/class-paramaters-no-inherits ()
+  (puppet-test-with-temp-buffer
+      "
+class foo (
+String $foo,
+) {
+}"
+    (indent-region (point-min) (point-max))
+    (should (string= (buffer-string)
+      "
+class foo (
+  String $foo,
+) {
+}"
+))))
+
+(ert-deftest puppet-indent-line/class-paramaters-inherits ()
+  (puppet-test-with-temp-buffer
+      "
+class foo::bar (
+String $foo,
+) inherits foo {
+}"
+    (indent-region (point-min) (point-max))
+    (should (string= (buffer-string)
+      "
+class foo::bar (
+  String $foo,
+) inherits foo {
+}"
+))))
+
 (ert-deftest puppet-indent-line/extra-indent-after-colon ()
   (puppet-test-with-temp-buffer
       "


### PR DESCRIPTION
Example for current behavior:

```
class foo (
  String $foo,
  ) {
  }
```

Expected:

```
class foo (
  String $foo,
) {
}
```

The current indent function toggles between the two above indentation
styles.  For a language like Python such behavior might be reasonable,
but not for Puppet in this case.

See https://github.com/voxpupuli/puppet-mode/issues/90