### PR TITLE
Skip nested block when aligning

### DIFF
--- a/puppet-mode.el
+++ b/puppet-mode.el
@@ -978,7 +978,11 @@ Used as `syntax-propertize-function' in Puppet Mode."
   "Align rules for Puppet Mode.")
 
 (defconst puppet-mode-align-exclude-rules
-  '((puppet-comment
+  '((puppet-nested
+     (regexp . "\\s-*=>\\s-*\\({[^}]*}\\)")
+     (modes  . '(puppet-mode))
+     (separate . entire))
+    (puppet-comment
      (regexp . "^\\s-*\#\\(.*\\)")
      (modes . '(puppet-mode))))
   "Rules for excluding lines from alignment for Puppet Mode.")

--- a/test/puppet-mode-test.el
+++ b/test/puppet-mode-test.el
@@ -519,9 +519,8 @@ package { 'bar':
   install_options => [],
 }"))))
 
-(ert-deftest puppet-align-block/nested-blocks ()
+(ert-deftest puppet-align-block/skip-nested-blocks ()
   :tags '(alignment)
-  :expected-result :failed
   (puppet-test-with-temp-buffer
       "
 package { 'foo':
@@ -541,7 +540,7 @@ package { 'foo':
   require         => Package['bar'],
   install_options => ['--foo', '--bar'],
   foo             => {
-    bar  => 'qux',
+    bar => 'qux',
     quxc => 'bar',
   }
 }"))))


### PR DESCRIPTION
Currently, all arrows will be aligned, including in nested blocks.

    class foo {
      $x = {
        'a'        => 1,
        'foo'      => {
          'apples' => 1,
        },
      }
    }

We get better behavior by skipping alignment in nested blocks.

https://github.com/voxpupuli/puppet-mode/issues/92