### PR TITLE
Handle aligning nested block before point

### DIFF
--- a/puppet-mode.el
+++ b/puppet-mode.el
@@ -991,14 +991,10 @@ Used as `syntax-propertize-function' in Puppet Mode."
   "Align the current block."
   (interactive)
   (save-excursion
-    (save-match-data
-      (let ((beg (search-backward "{" nil 'no-error)))
-        ;; Skip backwards over strings and comments
-        (while (and beg (puppet-in-string-or-comment-p beg))
-          (setq beg (search-backward "{" nil 'no-error)))
-        (when beg
-          (forward-list)
-          (align beg (point)))))))
+    (backward-up-list)
+    (let ((beg (point)))
+      (forward-list)
+      (align beg (point)))))
 
 
 ;;; Dealing with strings

--- a/puppet-mode.el
+++ b/puppet-mode.el
@@ -978,7 +978,11 @@ Used as `syntax-propertize-function' in Puppet Mode."
   "Align rules for Puppet Mode.")
 
 (defconst puppet-mode-align-exclude-rules
-  '((puppet-comment
+  '((puppet-nested
+     (regexp . "\\s-*=>\\s-*\\({[^}]*}\\)")
+     (modes  . '(puppet-mode))
+     (separate . entire))
+    (puppet-comment
      (regexp . "^\\s-*\#\\(.*\\)")
      (modes . '(puppet-mode))))
   "Rules for excluding lines from alignment for Puppet Mode.")

--- a/test/puppet-mode-test.el
+++ b/test/puppet-mode-test.el
@@ -561,6 +561,32 @@ package { 'foo':
   # require => Package['bar'],
 }"))))
 
+(ert-deftest puppet-align-block/skip-previous-nested-block ()
+  :tags '(alignment)
+   (puppet-test-with-temp-buffer
+      "
+class foo {
+  $x = {
+    'a'=>1,
+    'foo'=>{
+      'apples'=>1,
+    },
+    'metafalica'=>1,
+  }
+}"
+    (search-forward "'metafalica'")
+    (puppet-align-block)
+    (should (string= (buffer-string) "
+class foo {
+  $x = {
+    'a'          => 1,
+    'foo'        => {
+      'apples'=>1,
+    },
+    'metafalica' => 1,
+  }
+}"))))
+
 
 ;;;; Imenu
 

--- a/test/puppet-mode-test.el
+++ b/test/puppet-mode-test.el
@@ -519,9 +519,8 @@ package { 'bar':
   install_options => [],
 }"))))
 
-(ert-deftest puppet-align-block/nested-blocks ()
+(ert-deftest puppet-align-block/skip-nested-blocks ()
   :tags '(alignment)
-  :expected-result :failed
   (puppet-test-with-temp-buffer
       "
 package { 'foo':
@@ -541,7 +540,7 @@ package { 'foo':
   require         => Package['bar'],
   install_options => ['--foo', '--bar'],
   foo             => {
-    bar  => 'qux',
+    bar => 'qux',
     quxc => 'bar',
   }
 }"))))


### PR DESCRIPTION
When puppet-align-block searches for the beginning of a hash, it gets
confused by a previous nested block.  Use backward-up-list instead of
searching for a curly brace.

https://github.com/voxpupuli/puppet-mode/issues/93