### PR TITLE
Simplify puppet--in-listlike and puppet-block-indent

### DIFF
--- a/puppet-mode.el
+++ b/puppet-mode.el
@@ -527,22 +527,12 @@ When called interactively, prompt for COMMAND."
 block (the line containing the opening brace).  Used to set the indentation
 of the closing brace of a block."
   (save-excursion
-    (save-match-data
-      (let ((opoint (point))
-            (apoint (search-backward "{" nil t)))
-        (when apoint
-          ;; This is a bit of a hack and doesn't allow for strings.  We really
-          ;; want to parse by sexps at some point.
-          (let ((close-braces (count-matches "}" apoint opoint))
-                (open-braces 0))
-            (while (and apoint (> close-braces open-braces))
-              (setq apoint (search-backward "{" nil t))
-              (when apoint
-                (setq close-braces (count-matches "}" apoint opoint))
-                (setq open-braces (1+ open-braces)))))
-          (if apoint
-              (current-indentation)
-            nil))))))
+    (let ((opoint (nth 1 (syntax-ppss))))
+      (when (and opoint
+                 (progn
+                   (goto-char opoint)
+                   (looking-at-p "{")))
+        (current-indentation)))))
 
 (defun puppet-in-argument-list ()
   "If point is in an argument list, return the position of the opening '('.
@@ -559,14 +549,12 @@ that array, else return nil."
 it, else return nil.
 OPENSTRING is a regexp string matching the opening character."
   (save-excursion
-    (save-match-data
-      (condition-case nil
-          (progn
-            (backward-up-list)
-            (if (looking-at openstring)
-                (point)
-              nil))
-        (scan-error nil)))))
+    (let ((opoint (nth 1 (syntax-ppss))))
+      (when (and opoint
+                 (progn
+                   (goto-char opoint)
+                   (looking-at-p openstring)))
+        opoint))))
 
 (defun puppet-in-include ()
   "If point is in a continued list of include statements, return the position

--- a/test/puppet-mode-test.el
+++ b/test/puppet-mode-test.el
@@ -891,6 +891,74 @@ class foo {
 "
 ))))
 
+(ert-deftest puppet-indent-line/nested-hash-inside-array ()
+  (puppet-test-with-temp-buffer
+      "
+$shadow_config_settings = [
+{
+section => 'CROS',
+setting => 'dev_server',
+value   => join($dev_server, ','),
+require => Package['foo'],
+},
+]
+"
+    (indent-region (point-min) (point-max))
+    (should (string= (buffer-string)
+                     "
+$shadow_config_settings = [
+  {
+    section => 'CROS',
+    setting => 'dev_server',
+    value   => join($dev_server, ','),
+    require => Package['foo'],
+  },
+]
+"
+))))
+
+(ert-deftest puppet-indent-line/nested-hash-inside-array-inside-hash ()
+  (puppet-test-with-temp-buffer
+      "
+class openvpn::config {
+$defaultRules = [
+{
+'destination' => '192.168.540.162',
+'netmask' => '255.255.255.255',
+'protocol' => 'udp',
+'ports' => '53',
+},
+{
+'destination' => '192.168.540.163',
+'netmask' => '255.255.255.255',
+'protocol' => 'udp',
+'ports' => '53',
+},
+]
+}
+"
+    (indent-region (point-min) (point-max))
+    (should (string= (buffer-string)
+                     "
+class openvpn::config {
+  $defaultRules = [
+    {
+      'destination' => '192.168.540.162',
+      'netmask' => '255.255.255.255',
+      'protocol' => 'udp',
+      'ports' => '53',
+    },
+    {
+      'destination' => '192.168.540.163',
+      'netmask' => '255.255.255.255',
+      'protocol' => 'udp',
+      'ports' => '53',
+    },
+  ]
+}
+"
+))))
+
 
 ;;;; Major mode definition
 


### PR DESCRIPTION
Some further simplification of `puppet-in-array` using `syntax-ppss` instead of `condition-case`. `syntax-ppss` is also cached so it is possibly a bit faster.  Similarly simplified `puppet-block-indent`.

Added test cases for the following issues which are now fixed (they were probably already fixed by 4e9d805e43c76adb73d10c57011e260ff16e70f9)

Fixes #98 
Fixes #67 