### PR TITLE
Fixed puppet-lint log format based on new puppet-lint v2.3.0

### DIFF
--- a/puppet-mode.el
+++ b/puppet-mode.el
@@ -156,7 +156,7 @@ buffer-local wherever it is set."
 (defcustom puppet-lint-command
   (concat
    "puppet-lint --with-context "
-   "--log-format \"%{path}:%{linenumber}: %{kind}: %{message} (%{check})\"")
+   "--log-format \"%{path}:%{line}: %{kind}: %{message} (%{check})\"")
   "Command to lint a Puppet manifest."
   :type 'string
   :group 'puppet


### PR DESCRIPTION
Changed `linenumber` to `line` according to the new puppet-lint version.

Ref: https://github.com/rodjek/puppet-lint/issues/539