### PR TITLE
Fix indentation of closing braces

### DIFF
--- a/puppet-mode.el
+++ b/puppet-mode.el
@@ -643,10 +643,11 @@ of the initial include plus puppet-include-indent."
               (setq cur-indent (current-column))))))
        (include-start
         (setq cur-indent include-start))
-       ((and (looking-at "^\\s-*}\\(,\\|\\s-*[-~]>\\)?\\s-*$") block-indent)
-        ;; This line contains a closing brace or a closing brace followed by a
-        ;; comma and we're at the inner block, so we should indent it matching
-        ;; the indentation of the opening brace of the block.
+
+       ((and (looking-at "^\\s-*}.*$") block-indent)
+        ;; This line contains a closing brace and we're at the inner
+        ;; block, so we should indent it matching the indentation of
+        ;; the opening brace of the block.
         (setq cur-indent block-indent))
 
        ;; Class argument list ends with a closing paren and needs to be

--- a/test/puppet-mode-test.el
+++ b/test/puppet-mode-test.el
@@ -861,6 +861,86 @@ class foo {
 }"
 ))))
 
+(ert-deftest puppet-indent-line/if ()
+  (puppet-test-with-temp-buffer
+      "
+class foo {
+if $foo {
+$foo = 'bar'
+}
+}
+"
+    (indent-region (point-min) (point-max))
+    (should (string= (buffer-string)
+      "
+class foo {
+  if $foo {
+    $foo = 'bar'
+  }
+}
+"
+))))
+
+(ert-deftest puppet-indent-line/if-elsif-else ()
+  (puppet-test-with-temp-buffer
+      "
+class foo {
+if $foo == 'foo' {
+$bar = 'foo1'
+}
+elsif $foo == 'bar' {
+$bar = 'foo2'
+}
+else {
+$bar = 'foo3'
+}
+}
+"
+    (indent-region (point-min) (point-max))
+    (should (string= (buffer-string)
+      "
+class foo {
+  if $foo == 'foo' {
+    $bar = 'foo1'
+  }
+  elsif $foo == 'bar' {
+    $bar = 'foo2'
+  }
+  else {
+    $bar = 'foo3'
+  }
+}
+"
+))))
+
+(ert-deftest puppet-indent-line/if-statement-with-no-newline-after-closing-braces ()
+  (puppet-test-with-temp-buffer
+      "
+class foo {
+if $foo == 'foo' {
+$bar = 'foo1'
+} elsif $foo == 'bar' {
+$bar = 'foo2'
+} else {
+$bar = 'foo3'
+}
+}
+"
+    (indent-region (point-min) (point-max))
+    (should (string= (buffer-string)
+      "
+class foo {
+  if $foo == 'foo' {
+    $bar = 'foo1'
+  } elsif $foo == 'bar' {
+    $bar = 'foo2'
+  } else {
+    $bar = 'foo3'
+  }
+}
+"
+))))
+
 (ert-deftest puppet-indent-line/nested-hash ()
   (puppet-test-with-temp-buffer
       "


### PR DESCRIPTION
Fix indentation for closing braces not followed by newline. For example the closing brace on the same line as the else keyword in the following example:

    if $foo == 'foo' {
      $bar = 'foo1'
    } else {
      $bar = 'foo2'
    }

The regexp for detecting a closing brace is simplified to only look for a line that starts with a closing brace, removing explicit checks for optional trailing commas or chaining arrows.

All tests still pass, including new ones added that tests indentation of if statements.