### PR TITLE
Adds keywords and types for Puppet Bolt

### DIFF
--- a/puppet-mode.el
+++ b/puppet-mode.el
@@ -315,7 +315,11 @@ Return nil, if there is no special context at POS, or one of
                           "default" "define" "else" "elsif" "environment"
                           "false" "function" "if" "import" "in" "inherits"
                           "node" "or" "private" "produces" "site" "true"
-                          "type" "undef" "unless")))
+                          "type" "undef" "unless"
+                          ;; Bolt
+                          ;; https://puppet.com/docs/bolt/0.x/writing_plans.html
+                          "plan"
+                          )))
       ;; http://docs.puppetlabs.com/references/latest/function.html
       (builtin-function . ,(rx (or "alert" "assert_type" "binary_file" "break"
                                    "contain" "create_resources" "crit" "debug"
@@ -331,6 +335,15 @@ Return nil, if there is no special context at POS, or one of
                                    "shellquote" "slice" "split" "sprintf"
                                    "step" "strftime" "tag" "tagged" "template"
                                    "then" "type" "versioncmp" "warning" "with"
+                                   ;; Bolt
+                                   ;; https://puppet.com/docs/bolt/0.x/plan_functions.html
+                                   ;; https://puppet.com/docs/bolt/0.x/writing_plans.html#concept-4926
+                                   "apply" "apply_prep" "add_facts" "facts"
+                                   "fail_plan" "file_upload" "get_targets"
+                                   "puppetdb_fact" "puppetdb_query"
+                                   "run_command" "run_plan" "run_script"
+                                   "run_task" "set_feature" "set_var" "vars"
+                                   "without_default_logging" 
                                    )))
       ;; http://docs.puppetlabs.com/references/latest/type.html
       (builtin-type . ,(rx (or "augeas" "computer" "cron" "exec" "file"
@@ -375,6 +388,10 @@ Return nil, if there is no special context at POS, or one of
                          ;; Platform Types:
                          "Callable" "Default" "Runtime" "Sensitive" "Type"
                          "Undef"
+                         ;; Bolt types:
+                         ;; https://puppet.com/docs/bolt/0.x/writing_plans.html
+                         "Error" "PlanResult" "Result" "ResultSet" "Target"
+                         "TargetSpec"
                          )))
       ;; http://docs.puppetlabs.com/puppet/latest/reference/lang_reserved.html#classes-and-types
       (resource-name . ,(rx
@@ -790,7 +807,7 @@ of the initial include plus puppet-include-indent."
     ;; Variables
     (,(puppet-rx "$" (symbol variable-name)) 0 font-lock-variable-name-face)
     ;; Class and type declarations
-    (,(puppet-rx (symbol (or "class" "define"))
+    (,(puppet-rx (symbol (or "class" "define" "plan"))
                  (one-or-more space)
                  (group (symbol resource-name)))
      1 font-lock-type-face)

--- a/test/puppet-mode-test.el
+++ b/test/puppet-mode-test.el
@@ -314,6 +314,23 @@ class */ bar"
     (should (eq (puppet-test-face-at 23) 'font-lock-type-face))
     (should-not (puppet-test-face-at 25))))
 
+(ert-deftest puppet-font-lock-keywords/plan ()
+  :tags '(fontification font-lock-keywords)
+  (puppet-test-with-temp-buffer "plan foo::bar($foo) {"
+    ;; The keyword
+    (should (eq (puppet-test-face-at 1) 'font-lock-keyword-face))
+    ;; The scope
+    (should (eq (puppet-test-face-at 6) 'font-lock-type-face))
+    ;; The scope operator
+    (should (eq (puppet-test-face-at 9) 'font-lock-type-face))
+    ;; The name
+    (should (eq (puppet-test-face-at 11) 'font-lock-type-face))
+    ;; The parenthesis
+    (should-not (puppet-test-face-at 14))
+    ;; The parameter
+    (should (eq (puppet-test-face-at 15) 'font-lock-variable-name-face))
+    (should-not (puppet-test-face-at 19))))
+
 (ert-deftest puppet-font-lock-keywords/resource ()
   :tags '(fontification font-lock-keywords)
   (puppet-test-with-temp-buffer "foo::bar {"


### PR DESCRIPTION
Closes #114 

This PR adds new keywords and datatypes for [Puppet Bolt](https://puppet.com/docs/bolt/0.x/bolt.html).

Keywords and datatypes are defined here: https://puppet.com/docs/bolt/0.x/writing_plans.html

Functions are defined here: https://puppet.com/docs/bolt/0.x/plan_functions.html

Also there are new `apply` and `apply_prep` functions defined here: https://puppet.com/docs/bolt/0.x/writing_plans.html#concept-4926 