### PR TITLE
Add Debian (and derivatives) installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ Installation
 ------------
 
 From [MELPA][] or [MELPA Stable][] with <kbd>M-x package-install RET
-puppet-mode</kbd>.
+puppet-mode</kbd>.  Users of Debian ≥11 and derivatives can `sudo apt
+install elpa-puppet-mode`.  Manifest validation and linting support is
+enabled by installing the `elpa-flycheck` package.
 
 In your [`Cask`][cask] file:
 


### PR DESCRIPTION
Hi!

I'm opening this PR early, for discussion, but it's not ready to merge yet, because Debian 10 (buster) hasn't yet been released, thus the Debian 11 (bullseye) suite isn't yet available.  @rski, thanks for commenting at #116!  Your points encouraged me to demote flycheck to a suggested dependency (not automatically installed), on the basis of maximal user choice; that's why I think two sentences are needed here instead of the usual one ;-)

Cheers,
Nicholas

P.S. I'm also interested to see what will happen in response to recent Flymake development.