### PR TITLE
Fix indentation following array with nested hash

### DIFF
--- a/puppet-mode.el
+++ b/puppet-mode.el
@@ -711,6 +711,13 @@ of the initial include plus puppet-include-indent."
               (setq cur-indent (current-indentation))
               (setq not-indented nil))
 
+             ;; Closing bracket. Use indentation based on start of
+             ;; array.
+             ((looking-at "^[^[\n]*],?\\s-*$")
+              (goto-char (puppet-in-array))
+              (setq cur-indent (current-indentation))
+              (setq not-indented nil))
+
              ;; Brace, paren or bracket (possibly followed by a comma)
              ;; on a line by itself will already be indented to the
              ;; right level, so we can cheat and stop there.

--- a/puppet-mode.el
+++ b/puppet-mode.el
@@ -711,10 +711,10 @@ of the initial include plus puppet-include-indent."
               (setq cur-indent (current-indentation))
               (setq not-indented nil))
 
-             ;; Brace (possibly followed by a comma) or paren on a
-             ;; line by itself will already be indented to the right
-             ;; level, so we can cheat and stop there.
-             ((looking-at "^\\s-*[\)}]\\(,\\|\\s-*[-~]>\\)?\\s-*\s?$")
+             ;; Brace, paren or bracket (possibly followed by a comma)
+             ;; on a line by itself will already be indented to the
+             ;; right level, so we can cheat and stop there.
+             ((looking-at "^\\s-*[\)}\]]\\(,\\|\\s-*[-~]>\\)?\\s-*\s?$")
               (setq cur-indent (current-indentation))
               (setq not-indented nil))
 

--- a/puppet-mode.el
+++ b/puppet-mode.el
@@ -714,7 +714,7 @@ of the initial include plus puppet-include-indent."
              ;; Brace, paren or bracket (possibly followed by a comma)
              ;; on a line by itself will already be indented to the
              ;; right level, so we can cheat and stop there.
-             ((looking-at "^\\s-*[\)}\]]\\(,\\|\\s-*[-~]>\\)?\\s-*\s?$")
+             ((looking-at "^\\s-*[])}]\\(,\\|\\s-*[-~]>\\)?\\s-*\s?$")
               (setq cur-indent (current-indentation))
               (setq not-indented nil))
 


### PR DESCRIPTION
This proposed change fixes a problem which is identified in a comment
attached to issue 108:

https://github.com/voxpupuli/puppet-mode/issues/108#issuecomment-399312397

puppet-indent-line currently scans backwards in the buffer, line by
line, and if it finds a closing (brace or paren) (optionally followed
by a comma) then it records the current indentation level and returns
that as cur-indent.

If we nest data structures, this heuristic can break in the event that
the array list contains braces to denote a hash.

I propose to fix this issue by adding the closing bracket character to the
list of punctuation recognised by the heuristic - the backwards search of
the buffer then terminates at the "]," which denotes the end of the array,
and never gets confused by closing braces or closing parens embedded
within the array block.
